### PR TITLE
Consent status lifecycle

### DIFF
--- a/code/API_definitions/consent-management.yaml
+++ b/code/API_definitions/consent-management.yaml
@@ -30,7 +30,7 @@ info:
 
     A User Consent follows a defined status lifecycle. The possible statuses and their allowed transitions are described below and illustrated in the diagram:
 
-    - **PENDING**: Initial status indicating that the User Consent has not yet been requested from the User. No Consent record exists yet.
+    - **PENDING**: Initial status indicating that the User Consent has not yet been requested from the User. No Consent record (`consentId`) exists at this stage.
     - **REQUESTED**: The User Consent has been requested from the User, but the User has not yet responded. A Consent record exists with a `consentId`.
     - **GRANTED**: The User has approved the Consent, allowing the requested data processing. This status is set when creating or updating a Consent with status `GRANTED`.
     - **DENIED**: The User has rejected the Consent. This status is set when creating or updating a Consent with status `DENIED`.
@@ -42,10 +42,10 @@ info:
     - `PENDING/REQUESTED` → `DENIED`: The User rejects the Consent.
     - `GRANTED` → `DENIED`: The User revokes a previously granted Consent.
     - `DENIED` → `GRANTED`: The User reconsents after previously denying.
-    - `GRANTED` → `EXPIRED`: The Consent TTL is reached.
-    - `DENIED` → `EXPIRED`: The Consent TTL is reached.
-    - `EXPIRED` → `GRANTED`: The User renews and approves an expired Consent.
-    - `EXPIRED` → `DENIED`: The User renews and rejects an expired Consent.
+    - `GRANTED` → `EXPIRED`: The Consent TTL is reached and the Consent expires.
+    - `DENIED` → `EXPIRED`: The Consent TTL is reached and the Consent expires.
+    - `EXPIRED` → `GRANTED`: The User renews and approves an expired Consent. It requires the API Consumer to recapture the User Consent and update the Consent status to `GRANTED` via the `updateConsent` operation.
+    - `EXPIRED` → `DENIED`: The User renews and rejects an expired Consent. It requires the API Consumer to recapture the User Consent and update the Consent status to `DENIED` via the `updateConsent` operation.
 
     Note that API Consumers can only set a Consent status to `GRANTED` or `DENIED` via the `createConsent` and `updateConsent` operations. The `PENDING`, `REQUESTED`, and `EXPIRED` statuses are managed by the API Provider.
 

--- a/code/API_definitions/consent-management.yaml
+++ b/code/API_definitions/consent-management.yaml
@@ -34,7 +34,7 @@ info:
     - **REQUESTED**: The User Consent has been requested from the User, but the User has not yet responded. A Consent record exists with a `consentId`.
     - **GRANTED**: The User has approved the Consent, allowing the requested data processing. This status is set when creating or updating a Consent with status `GRANTED`.
     - **DENIED**: The User has rejected the Consent. This status is set when creating or updating a Consent with status `DENIED`.
-    - **EXPIRED**: The User Consent has expired because its TTL (time-to-live) has been reached. Both `GRANTED` and `DENIED` Consents can expire.
+    - **EXPIRED**: The User Consent has expired because its TTL (time-to-live) has been reached. Both `GRANTED` and `DENIED` Consents can expire. The API Provider determines the expiration date based on its internal policies.
 
     The allowed transitions are:
 

--- a/code/API_definitions/consent-management.yaml
+++ b/code/API_definitions/consent-management.yaml
@@ -26,6 +26,54 @@ info:
 
     It is important to note that the API Provider remains fully responsible for Consent storage, auditing and transparency. Access to this functionality is restricted to trusted API Consumers in accordance with the API Provider's policy. This API only applies to scenarios involving the legal basis of Consent. Scenarios involving a different legal basis for data processing are excluded and would be handled by the API Provider through non-delegated mechanisms.
 
+    ## Consent status lifecycle
+
+    A User Consent follows a defined status lifecycle. The possible statuses and their allowed transitions are described below and illustrated in the diagram:
+
+    - **PENDING**: Initial status indicating that the User Consent has not yet been requested from the User. No Consent record exists yet.
+    - **REQUESTED**: The User Consent has been requested from the User, but the User has not yet responded. A Consent record exists with a `consentId`.
+    - **GRANTED**: The User has approved the Consent, allowing the requested data processing. This status is set when creating or updating a Consent with status `GRANTED`.
+    - **DENIED**: The User has rejected the Consent. This status is set when creating or updating a Consent with status `DENIED`.
+    - **EXPIRED**: The User Consent has expired because its TTL (time-to-live) has been reached. Both `GRANTED` and `DENIED` Consents can expire.
+
+    The allowed transitions are:
+
+    - `PENDING/REQUESTED` → `GRANTED`: The User approves the Consent.
+    - `PENDING/REQUESTED` → `DENIED`: The User rejects the Consent.
+    - `GRANTED` → `DENIED`: The User revokes a previously granted Consent.
+    - `DENIED` → `GRANTED`: The User reconsents after previously denying.
+    - `GRANTED` → `EXPIRED`: The Consent TTL is reached.
+    - `DENIED` → `EXPIRED`: The Consent TTL is reached.
+    - `EXPIRED` → `GRANTED`: The User renews and approves an expired Consent.
+    - `EXPIRED` → `DENIED`: The User renews and rejects an expired Consent.
+
+    Note that API Consumers can only set a Consent status to `GRANTED` or `DENIED` via the `createConsent` and `updateConsent` operations. The `PENDING`, `REQUESTED`, and `EXPIRED` statuses are managed by the API Provider.
+
+    The following diagram illustrates the allowed status transitions:
+
+    ```
+               ┌─────────────────────┐
+               │  PENDING/REQUESTED  │
+               └──┬───────────────┬──┘
+                  │               │
+            User Rejects    User Approves
+                  │               │
+      ┌───────────▼───┐  Rev. ┌───▼───────────┐
+      │               │◄──────┤               │
+      │    DENIED     │       │    GRANTED    │
+      │               │───────►               │
+      └─────┬───▲─────┘Re-con.└──────┬───▲────┘
+            │   │                    │   │
+        TTL │   │ Renewed        TTL │   │ Renewed
+    Reached │   │ & Rejected Reached │   │ & Approved
+            │   │                    │   │
+      ┌─────▼───┴────────────────────▼───┴────┐
+      │                                       │
+      │                EXPIRED                │
+      │                                       │
+      └───────────────────────────────────────┘
+    ```
+
     # Authorization and authentication
 
     The "Camara Security and Interoperability Profile" provides details of how an API consumer requests an access token. Please refer to Identity and Consent Management (https://github.com/camaraproject/IdentityAndConsentManagement/) for the released version of the profile.

--- a/code/API_definitions/consent-management.yaml
+++ b/code/API_definitions/consent-management.yaml
@@ -55,7 +55,7 @@ info:
                 +-----------------+
                 |PENDING/REQUESTED|
                 +--+------------+-+
-                   |            | 
+                   |            |
              User Rejects  User Approves
           +--------+            +-------+
           |                             |

--- a/code/API_definitions/consent-management.yaml
+++ b/code/API_definitions/consent-management.yaml
@@ -52,26 +52,29 @@ info:
     The following diagram illustrates the allowed status transitions:
 
     ```
-               ┌─────────────────────┐
-               │  PENDING/REQUESTED  │
-               └──┬───────────────┬──┘
-                  │               │
-            User Rejects    User Approves
-                  │               │
-      ┌───────────▼───┐  Rev. ┌───▼───────────┐
-      │               │◄──────┤               │
-      │    DENIED     │       │    GRANTED    │
-      │               │───────►               │
-      └─────┬───▲─────┘Re-con.└──────┬───▲────┘
-            │   │                    │   │
-        TTL │   │ Renewed        TTL │   │ Renewed
-    Reached │   │ & Rejected Reached │   │ & Approved
-            │   │                    │   │
-      ┌─────▼───┴────────────────────▼───┴────┐
-      │                                       │
-      │                EXPIRED                │
-      │                                       │
-      └───────────────────────────────────────┘
+                +-----------------+
+                |PENDING/REQUESTED|
+                +--+------------+-+
+                   |            | 
+             User Rejects  User Approves
+          +--------+            +-------+
+          |                             |
+    +-----v--------+            +-------v------+
+    |              <-Revocation-+              |
+    |   DENIED     +-Re-consent->   GRANTED    |
+    |              +-+        +-+              |
+    +---^----------+ |        | +--------^-----+
+        |            |        |          |
+        |       TTL Reached   |          |
+        |            |        |          |
+        |            |   TTL Reached     |
+        |            |        |          |
+     Renewed         |        |       Renewed
+    & Rejected    +--v--------v--+   & Approved
+        |         |              |       |
+        +---------+   EXPIRED    +-------+
+                  |              |
+                  +--------------+
     ```
 
     # Authorization and authentication


### PR DESCRIPTION
#### What type of PR is this?

* enhancement/feature
* documentation

#### What this PR does / why we need it:

This pull request adds detailed documentation about the consent status lifecycle to the `consent-management.yaml` API definition. It introduces clear descriptions of each consent status, outlines the allowed transitions between statuses, and provides a diagram to help visualize the lifecycle. This documentation will help both API Providers and Consumers understand how consent statuses are managed and what transitions are possible.

Enhancements to consent status documentation:

* Added a new section describing the consent status lifecycle, including definitions for `PENDING`, `REQUESTED`, `GRANTED`, `DENIED`, and `EXPIRED` statuses, as well as the allowed transitions between them.
* Included a diagram illustrating the possible consent status transitions for easier understanding and reference.
* Clarified that API Consumers can only set consent statuses to `GRANTED` or `DENIED`, while other statuses are managed by the API Provider.

#### Which issue(s) this PR fixes:

Fixes #13 

#### Special notes for reviewers:

I've decided to include the diagram in ASCII format. It would be possible to include a picture instead, but it would require managing it as a repository asset and updating the URL pointing to the picture with every release. Although this is standard practice in other API projects, if the reviewers deem the ASCII diagram sufficient and properly visualized, I will follow this approach instead of maintaining the image asset.

<img width="251" height="205" alt="Consent Management - Consent State Machine" src="https://github.com/user-attachments/assets/9b0332ab-fd9a-4a1c-99d3-e199df67c3a3" />

#### Changelog input

```
Consent status lifecycle
```

#### Additional documentation 

N/A
