### PR TITLE
Plan update for first release candidate r1.1

### DIFF
--- a/release-plan.yaml
+++ b/release-plan.yaml
@@ -20,7 +20,7 @@ repository:
 
   # Release type being prepared (must be set before release can be triggered)
   # Options: none | pre-release-alpha | pre-release-rc | public-release | maintenance-release
-  target_release_type: none
+  target_release_type: pre-release-rc
 
 # Dependencies on Commonalities and ICM releases
 # Update per ReleaseManagement requirements for each release cycle
@@ -35,7 +35,7 @@ dependencies:
 apis:
   - api_name: consent-management
     target_api_version: 0.1.0
-    target_api_status: draft
+    target_api_status: rc
     main_contacts:
       - jpengar
       - AxelNennker

--- a/release-plan.yaml
+++ b/release-plan.yaml
@@ -25,8 +25,8 @@ repository:
 # Dependencies on Commonalities and ICM releases
 # Update per ReleaseManagement requirements for each release cycle
 dependencies:
-  commonalities_release: r3.4
-  identity_consent_management_release: r3.3
+  commonalities_release: r4.2
+  identity_consent_management_release: r4.2
 
 # APIs in this repository
 # Replace the placeholder below when planning a release:


### PR DESCRIPTION

#### What type of PR is this?

* repository management

#### What this PR does / why we need it:

This pull request updates the release configuration in `release-plan.yaml` to prepare for a release candidate.

Release plan updates:

* Updated `target_release_type` in `release-plan.yaml` to `pre-release-rc`.
* Updated the dependencies to the latest Commonalities and ICM releases. **NOTE: The Commonalities release will have to be updated to 4.3 when the public release is available.**
* Updated `target_api_status` to `rc` to `public` in `release-plan.yaml`, reflecting the target public release.

#### Which issue(s) this PR fixes:

N/A

#### Special notes for reviewers:

This is a prerequisite for starting the automated generation of the first release candidate of the API.

#### Changelog input

```
Plan update for the first release candidate r1.1
```

#### Additional documentation 

- https://github.com/camaraproject/ReleaseManagement/blob/main/documentation/README.md
- https://github.com/camaraproject/ReleaseManagement/blob/main/documentation/release-process/lifecycle.md
