### PR TITLE
API spec updated to apply required changes from Commonalities r4.3

### DIFF
--- a/code/API_definitions/consent-management.yaml
+++ b/code/API_definitions/consent-management.yaml
@@ -114,7 +114,7 @@ info:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html
   version: wip
-  x-camara-commonalities: 0.6
+  x-camara-commonalities: 0.8.0
 externalDocs:
   description: Product documentation at CAMARA
   url: https://github.com/camaraproject/ConsentInfo
@@ -440,9 +440,7 @@ paths:
 components:
   headers:
     x-correlator:
-      description: Correlation id for the different services
-      schema:
-        $ref: "#/components/schemas/XCorrelator"
+      $ref: "../common/CAMARA_common.yaml#/components/headers/x-correlator"
     Content-Language:
       description: |
         The language of the response content, following the standard defined in [RFC 7231, Section 5.3.5](https://datatracker.ietf.org/doc/html/rfc7231#section-5.3.5) using language tags as defined by [BCP 47](https://tools.ietf.org/html/bcp47).
@@ -452,11 +450,7 @@ components:
         $ref: "#/components/schemas/LanguageTags"
   parameters:
     x-correlator:
-      name: x-correlator
-      in: header
-      description: Correlation id for the different services
-      schema:
-        $ref: "#/components/schemas/XCorrelator"
+      $ref: "../common/CAMARA_common.yaml#/components/parameters/x-correlator"
     Accept-Language:
       name: Accept-Language
       in: header
@@ -468,15 +462,9 @@ components:
         $ref: "#/components/schemas/LanguageTags"
   schemas:
     XCorrelator:
-      description: Value for the x-correlator
-      type: string
-      pattern: ^[a-zA-Z0-9-_:;.\/<>{}]{0,256}$
-      example: "b4333c46-49c0-4f62-80d7-f0ef930f1c46"
+      $ref: "../common/CAMARA_common.yaml#/components/schemas/XCorrelator"
     PhoneNumber:
-      type: string
-      description: A public identifier addressing a telephone subscription. In mobile networks it corresponds to the MSISDN (Mobile Station International Subscriber Directory Number). In order to be globally unique it has to be formatted in international format, according to E.164 standard, prefixed with '+'.
-      pattern: '^\+[1-9][0-9]{4,14}$'
-      example: "+123456789"
+      $ref: "../common/CAMARA_common.yaml#/components/schemas/PhoneNumber"
     CreateConsentRequestBody:
       type: object
       description: |
@@ -701,21 +689,7 @@ components:
         It must follow [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339#section-5.6) and must have time zone. Recommended format is yyyy-MM-dd'T'HH:mm:ss.SSSZ (i.e. which allows 2023-07-03T14:27:08.312+02:00 or 2023-07-03T12:27:08.312Z).
       example: "2026-07-03T14:27:08.312+02:00"
     ErrorInfo:
-      type: object
-      required:
-        - status
-        - code
-        - message
-      properties:
-        status:
-          type: integer
-          description: HTTP response status code
-        code:
-          type: string
-          description: A human-readable code to describe the error
-        message:
-          type: string
-          description: A human-readable description of what the event represents
+      $ref: "../common/CAMARA_common.yaml#/components/schemas/ErrorInfo"
   responses:
     Generic400:
       description: Bad Request
@@ -775,30 +749,7 @@ components:
                 code: CONSENT_MGMT.INVALID_CONSENT_TEXT_ID
                 message: The consentTextId provided is either invalid or does not exist.
     Generic401:
-      description: Unauthorized
-      headers:
-        x-correlator:
-          $ref: "#/components/headers/x-correlator"
-      content:
-        application/json:
-          schema:
-            allOf:
-              - $ref: "#/components/schemas/ErrorInfo"
-              - type: object
-                properties:
-                  status:
-                    enum:
-                      - 401
-                  code:
-                    enum:
-                      - UNAUTHENTICATED
-          examples:
-            GENERIC_401_UNAUTHENTICATED:
-              description: Request cannot be authenticated
-              value:
-                status: 401
-                code: UNAUTHENTICATED
-                message: Request not authenticated due to missing, invalid, or expired credentials. A new authentication is required.
+      $ref: "../common/CAMARA_common.yaml#/components/responses/Generic401"
     Generic403:
       description: Forbidden
       headers:
@@ -857,37 +808,7 @@ components:
                 code: CONSENT_MGMT.NOT_ALLOWED_SCOPES_PURPOSE
                 message: The requested scope(s) and Purpose combination is not allowed for this API Consumer.
     Generic404:
-      description: Not found
-      headers:
-        x-correlator:
-          $ref: "#/components/headers/x-correlator"
-      content:
-        application/json:
-          schema:
-            allOf:
-              - $ref: "#/components/schemas/ErrorInfo"
-              - type: object
-                properties:
-                  status:
-                    enum:
-                      - 404
-                  code:
-                    enum:
-                      - NOT_FOUND
-                      - IDENTIFIER_NOT_FOUND
-          examples:
-            GENERIC_404_NOT_FOUND:
-              description: Resource is not found
-              value:
-                status: 404
-                code: NOT_FOUND
-                message: The specified resource is not found.
-            GENERIC_404_IDENTIFIER_NOT_FOUND:
-              description: Some identifier cannot be matched to a device
-              value:
-                status: 404
-                code: IDENTIFIER_NOT_FOUND
-                message: Phone number not found.
+      $ref: "../common/CAMARA_common.yaml#/components/responses/Generic404"
     UpdateConsent404:
       description: Not found
       headers:
@@ -979,5 +900,4 @@ components:
                 message: The phone number is already identified by the access token.
   securitySchemes:
     openId:
-      type: openIdConnect
-      openIdConnectUrl: https://example.org/.well-known/openid-configuration
+      $ref: "../common/CAMARA_common.yaml#/components/securitySchemes/openId"

--- a/code/API_definitions/consent-management.yaml
+++ b/code/API_definitions/consent-management.yaml
@@ -77,6 +77,7 @@ info:
                   +--------------+
     ```
 
+    <!-- CAMARA:MANDATORY:authorization-and-authentication:BEGIN -->
     # Authorization and authentication
 
     The "Camara Security and Interoperability Profile" provides details of how an API consumer requests an access token. Please refer to Identity and Consent Management (https://github.com/camaraproject/IdentityAndConsentManagement/) for the released version of the profile.
@@ -84,7 +85,9 @@ info:
     The specific authorization flows to be used will be agreed upon during the onboarding process, happening between the API consumer and the API provider, taking into account the declared purpose for accessing the API, whilst also being subject to the prevailing legal framework dictated by local legislation.
 
     In cases where personal data is processed by the API and users can exercise their rights through mechanisms such as opt-in and/or opt-out, the use of three-legged access tokens is mandatory. This ensures that the API remains in compliance with privacy regulations, upholding the principles of transparency and user-centric privacy-by-design.
+    <!-- CAMARA:MANDATORY:authorization-and-authentication:END -->
 
+    <!-- CAMARA:MANDATORY:identifying-phone-number-from-access-token:BEGIN -->
     # Identifying the phone number from the access token
 
     This API requires the API consumer to identify a phone number as the subject of the API as follows:
@@ -98,7 +101,9 @@ info:
     - If the subject cannot be identified from the access token and the optional `phoneNumber` field is not included in the request, then the server will return an error with the `422 MISSING_IDENTIFIER` error code.
 
     - If the subject can be identified from the access token and the optional `phoneNumber` field is also included in the request, then the server will return an error with the `422 UNNECESSARY_IDENTIFIER` error code. This will be the case even if the same phone number is identified by these two methods, as the server is unable to make this comparison.
+    <!-- CAMARA:MANDATORY:identifying-phone-number-from-access-token:END -->
 
+    <!-- CAMARA:MANDATORY:additional-error-responses:BEGIN -->
     # Additional CAMARA error responses
 
     The list of error codes in this API specification is not exhaustive. Therefore the API specification MAY not document some non-mandatory error statuses as indicated in `CAMARA API Design Guide`.
@@ -106,10 +111,13 @@ info:
     Please refer to the `CAMARA_common.yaml` of the Commonalities Release associated to this API version for a complete list of error responses. The applicable Commonalities Release can be identified in the `API Readiness Checklist` document associated to this API version.
 
     As a specific rule, error `501 - NOT_IMPLEMENTED` can be only a possible error response if it is explicitly documented in the API.
+    <!-- CAMARA:MANDATORY:additional-error-responses:END -->
 
+    <!-- CAMARA:MANDATORY:request-body-strictness:BEGIN -->
     # Request body strictness
 
     This API rejects requests with JSON request bodies that contain properties not declared in this specification, at any nesting level. Unknown properties result in a `400 INVALID_ARGUMENT` response.
+    <!-- CAMARA:MANDATORY:request-body-strictness:END -->
 
     # Further info and support
 

--- a/code/API_definitions/consent-management.yaml
+++ b/code/API_definitions/consent-management.yaml
@@ -226,6 +226,7 @@ paths:
           description: The unique identifier of the User Consent
           schema:
             type: string
+            maxLength: 256
           example: "consent-123456"
       requestBody:
         required: true
@@ -461,8 +462,6 @@ components:
       schema:
         $ref: "#/components/schemas/LanguageTags"
   schemas:
-    XCorrelator:
-      $ref: "../common/CAMARA_common.yaml#/components/schemas/XCorrelator"
     PhoneNumber:
       $ref: "../common/CAMARA_common.yaml#/components/schemas/PhoneNumber"
     CreateConsentRequestBody:
@@ -488,8 +487,11 @@ components:
     Scopes:
       type: array
       minItems: 1
+      maxItems: 50
       items:
         type: string
+        description: A string representing a specific access right or action an API Consumer requests from the User for their data.
+        maxLength: 256
       description: |
         List of requested scopes. The scope is a string that represents the access rights that the API Consumer is requesting from the User.
       example:
@@ -497,6 +499,7 @@ components:
     Purpose:
       type: string
       pattern: '^dpv:[a-zA-Z0-9]+$'
+      maxLength: 256
       description: |
         The reason for which personal data will be processed by the API Consumer. CAMARA defines a standard set of Purposes which can be used by API Consumers to specify the reason for their intended personal data processing. CAMARA uses the [W3C Data Privacy Vocabulary](https://w3c.github.io/dpv/2.0/dpv/) (DPV) to represent these purposes e.g. `dpv:FraudPreventionAndDetection` or `dpv:RequestedServiceProvision`.
       example: "dpv:FraudPreventionAndDetection"
@@ -520,6 +523,7 @@ components:
       properties:
         consentId:
           type: string
+          maxLength: 256
           description: The unique identifier of the User Consent
           example: "consent-123456"
         creationDate:
@@ -555,6 +559,7 @@ components:
       properties:
         consentId:
           type: string
+          maxLength: 256
           description: The unique identifier of the User Consent
           example: "consent-123456"
         creationDate:
@@ -585,11 +590,13 @@ components:
           example: true
     RetrieveConsentInfoResponseBody:
       type: array
+      maxItems: 100
       description: The response body for the retrieveConsentInfo operation
       items:
         $ref: "#/components/schemas/ConsentInfoItem"
     ConsentInfoItem:
       type: object
+      description: A Consent Information entry for a given User, scope(s) and Purpose.
       required:
         - scopes
         - purpose
@@ -601,6 +608,7 @@ components:
           $ref: "#/components/schemas/Purpose"
         consentId:
           type: string
+          maxLength: 256
           description: The unique identifier of the User Consent
           example: "consent-123456"
         consentStatus:
@@ -643,10 +651,12 @@ components:
       properties:
         title:
           type: string
+          maxLength: 256
           description: The localized text title
           example: "Consent Required"
         description:
           type: string
+          maxLength: 4096
           description: The localized text description
           example: "Please provide your consent to proceed with location verification for fraud prevention."
         consentTextId:
@@ -654,6 +664,7 @@ components:
         lastUpdate:
           type: string
           format: date-time
+          maxLength: 64
           description: |
             The date and time when this consent text version was last updated.
 
@@ -661,10 +672,12 @@ components:
           example: "2025-07-03T14:27:08.312+02:00"
     LanguageTags:
       type: string
+      maxLength: 64
       description: List of Language tags that identify natural languages, following [BCP 47](https://tools.ietf.org/html/bcp47) standard.
       example: "en-US"
     ConsentTextId:
       type: string
+      maxLength: 256
       description: |
         This is a unique, immutable (e.g. hash-based) string identifier that designates a specific version of a legal text presented to the User during the Consent Capture process.
 
@@ -675,6 +688,7 @@ components:
     CreationDate:
       type: string
       format: date-time
+      maxLength: 64
       description: |
         The date and time at which the User Consent was created.
 
@@ -683,6 +697,7 @@ components:
     ExpirationDate:
       type: string
       format: date-time
+      maxLength: 64
       description: |
         The date and time at which the validity of the User Consent is set to expire or has expired (when applicable). The API Provider determines the expiration date based on its internal policies.
 

--- a/code/API_definitions/consent-management.yaml
+++ b/code/API_definitions/consent-management.yaml
@@ -81,7 +81,7 @@ info:
 
     The "Camara Security and Interoperability Profile" provides details of how an API consumer requests an access token. Please refer to Identity and Consent Management (https://github.com/camaraproject/IdentityAndConsentManagement/) for the released version of the profile.
 
-    The specific authorization flows to be used will be agreed upon during the onboarding process, happening between the API consumer and the API provider, taking into account the declared Purpose for accessing the API, whilst also being subject to the prevailing legal framework dictated by local legislation.
+    The specific authorization flows to be used will be agreed upon during the onboarding process, happening between the API consumer and the API provider, taking into account the declared purpose for accessing the API, whilst also being subject to the prevailing legal framework dictated by local legislation.
 
     In cases where personal data is processed by the API and users can exercise their rights through mechanisms such as opt-in and/or opt-out, the use of three-legged access tokens is mandatory. This ensures that the API remains in compliance with privacy regulations, upholding the principles of transparency and user-centric privacy-by-design.
 
@@ -101,11 +101,15 @@ info:
 
     # Additional CAMARA error responses
 
-    The list of error codes in this API specification is not exhaustive. Therefore the API specification may not document some non-mandatory error statuses as indicated in `CAMARA API Design Guide`.
+    The list of error codes in this API specification is not exhaustive. Therefore the API specification MAY not document some non-mandatory error statuses as indicated in `CAMARA API Design Guide`.
 
     Please refer to the `CAMARA_common.yaml` of the Commonalities Release associated to this API version for a complete list of error responses. The applicable Commonalities Release can be identified in the `API Readiness Checklist` document associated to this API version.
 
     As a specific rule, error `501 - NOT_IMPLEMENTED` can be only a possible error response if it is explicitly documented in the API.
+
+    # Request body strictness
+
+    This API rejects requests with JSON request bodies that contain properties not declared in this specification, at any nesting level. Unknown properties result in a `400 INVALID_ARGUMENT` response.
 
     # Further info and support
 
@@ -672,6 +676,7 @@ components:
           example: "2025-07-03T14:27:08.312+02:00"
     LanguageTags:
       type: string
+      pattern: '^[a-zA-Z]{2,3}(-[a-zA-Z0-9]{2,8})*$'
       maxLength: 64
       description: List of Language tags that identify natural languages, following [BCP 47](https://tools.ietf.org/html/bcp47) standard.
       example: "en-US"

--- a/code/Test_definitions/consent-management-createConsent.feature
+++ b/code/Test_definitions/consent-management-createConsent.feature
@@ -25,7 +25,7 @@ Feature: CAMARA Consent Management API, vwip - Operation createConsent
     And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"
     And the request body is set by default to a request body compliant with the schema at "#/components/schemas/CreateConsentRequestBody"
 
-  # Success scenarios
+  ############################ Happy Path Scenarios #############################################
 
   @consent_management_createConsent_01_success
   Scenario Outline: Create Consent successfully
@@ -34,6 +34,7 @@ Feature: CAMARA Consent Management API, vwip - Operation createConsent
     And the request body property "$.purpose" is set to a valid purpose for the requested scope(s)
     And the request body property "$.consentTextId" is set to a valid consentTextId for the requested scope(s) and purpose
     And the request body property "$.consentStatus" is set to "<consentStatus>"
+    And the request body is compliant with the schema at "#/components/schemas/CreateConsentRequestBody"
     When the request "createConsent" is sent
     Then the response status code is 201
     And the response header "Content-Type" is "application/json"
@@ -61,6 +62,8 @@ Feature: CAMARA Consent Management API, vwip - Operation createConsent
     And the response property "$.consentId" is present
     And the response property "$.creationDate" is present
     And the response property "$.expirationDate" is present and its value is in the future
+
+  ############################ Error Scenarios #############################################
 
   # Error scenarios for management of input parameter phoneNumber (C02)
 
@@ -114,73 +117,106 @@ Feature: CAMARA Consent Management API, vwip - Operation createConsent
     And the response property "$.code" is "SERVICE_NOT_APPLICABLE"
     And the response property "$.message" contains a user friendly text
 
-  # Generic 400 errors
+  # Syntax Error scenarios
 
-  @consent_management_createConsent_400.1_no_request_body
-  Scenario: Missing request body
-    Given the request body is not included
+  @consent_management_createConsent_400.01_schema_not_compliant
+  Scenario: Invalid Argument. Generic Syntax Exception
+    Given the request body is included but is not compliant with the schema at "#/components/schemas/CreateConsentRequestBody"
     When the request "createConsent" is sent
     Then the response status code is 400
+    And the response header "x-correlator" has same value as the request header "x-correlator"
+    And the response header "Content-Type" is "application/json"
     And the response property "$.status" is 400
     And the response property "$.code" is "INVALID_ARGUMENT"
     And the response property "$.message" contains a user friendly text
 
-  @consent_management_createConsent_400.2_missing_required_property
-  Scenario Outline: Missing required property in request body
-    Given the request body property "<input_property>" is not included
+  @consent_management_createConsent_400.02_no_request_body
+  Scenario: Missing request body
+    Given the request body is not included
     When the request "createConsent" is sent
     Then the response status code is 400
+    And the response header "x-correlator" has same value as the request header "x-correlator"
+    And the response header "Content-Type" is "application/json"
+    And the response property "$.status" is 400
+    And the response property "$.code" is "INVALID_ARGUMENT"
+    And the response property "$.message" contains a user friendly text
+
+  @consent_management_createConsent_400.03_empty_request_body
+  # 3-legged scenario only. It happens when request body has at least one required property
+  # NOTE: Recommended value for "$.message" (NOT NORMATIVE) is "Missing mandatory parameter(s)"
+  Scenario: Empty object as request body
+    Given the request body is set to {}
+    When the request "createConsent" is sent
+    Then the response status code is 400
+    And the response header "x-correlator" has same value as the request header "x-correlator"
+    And the response header "Content-Type" is "application/json"
+    And the response property "$.status" is 400
+    And the response property "$.code" is "INVALID_ARGUMENT"
+    And the response property "$.message" contains a user friendly text
+
+  @consent_management_createConsent_400.04_missing_required_property-
+  Scenario Outline: Error response for missing required property in request body
+    Given the request body property "<required_property>" is not included
+    When the request "createConsent" is sent
+    Then the response status code is 400
+    And the response header "x-correlator" has same value as the request header "x-correlator"
+    And the response header "Content-Type" is "application/json"
     And the response property "$.status" is 400
     And the response property "$.code" is "INVALID_ARGUMENT"
     And the response property "$.message" contains a user friendly text
 
     Examples:
-      | input_property  |
-      | $.scopes        |
-      | $.purpose       |
-      | $.consentStatus |
-      | $.consentTextId |
+      | required_property  |
+      | $.scopes           |
+      | $.purpose          |
+      | $.consentStatus    |
+      | $.consentTextId    |
 
-  @consent_management_createConsent_400.3_scopes_empty_array
+  @consent_management_createConsent_400.05_invalid_x-correlator
+  Scenario: Invalid x-correlator header
+    Given the header "x-correlator" does not comply with the schema at "#/components/schemas/XCorrelator"
+    When the request "createConsent" is sent
+    Then the response status code is 400
+    And the response property "$.status" is 400
+    And the response property "$.code" is "INVALID_ARGUMENT"
+    And the response property "$.message" contains a user friendly text
+
+  @consent_management_createConsent_400.06_scopes_empty_array
   Scenario: The scopes field is an empty array
     Given the request body property "$.scopes" is set to []
     When the request "createConsent" is sent
     Then the response status code is 400
+    And the response header "x-correlator" has same value as the request header "x-correlator"
+    And the response header "Content-Type" is "application/json"
     And the response property "$.status" is 400
     And the response property "$.code" is "INVALID_ARGUMENT"
     And the response property "$.message" contains a user friendly text
 
-  @consent_management_createConsent_400.4_purpose_invalid_format
+  @consent_management_createConsent_400.07_purpose_invalid_format
   Scenario: The purpose field does not comply with the required format
     Given the request body property "$.purpose" does not comply with the OAS schema at "#/components/schemas/Purpose"
     When the request "createConsent" is sent
     Then the response status code is 400
+    And the response header "x-correlator" has same value as the request header "x-correlator"
+    And the response header "Content-Type" is "application/json"
     And the response property "$.status" is 400
     And the response property "$.code" is "INVALID_ARGUMENT"
     And the response property "$.message" contains a user friendly text
 
-  @consent_management_createConsent_400.5_consentStatus_invalid_value
+  @consent_management_createConsent_400.08_consentStatus_invalid_value
   Scenario: The consentStatus field has an invalid value
     Given the request body property "$.consentStatus" is set to a value not in the allowed enum ["GRANTED", "DENIED"]
     When the request "createConsent" is sent
     Then the response status code is 400
-    And the response property "$.status" is 400
-    And the response property "$.code" is "INVALID_ARGUMENT"
-    And the response property "$.message" contains a user friendly text
-
-  @consent_management_createConsent_400.6_x_correlator_not_compliant
-  Scenario: Invalid x-correlator header
-    Given the header "x-correlator" is set to a value which is not compliant with the schema at "#/components/schemas/XCorrelator"
-    And the request body is set to a valid request body
-    When the request "createConsent" is sent
-    Then the response status code is 400
+    And the response header "x-correlator" has same value as the request header "x-correlator"
+    And the response header "Content-Type" is "application/json"
     And the response property "$.status" is 400
     And the response property "$.code" is "INVALID_ARGUMENT"
     And the response property "$.message" contains a user friendly text
 
   # Specific 400 error scenarios
 
-  @consent_management_createConsent_400.7_invalid_consent_text_id
+  @consent_management_createConsent_400.09_invalid_consent_text_id
   Scenario: Invalid consent text ID
     Given a valid phone number identified by the token or provided in the request body
     And the request body property "$.scopes" is set to a valid scope list allowed for the API Consumer
@@ -189,72 +225,95 @@ Feature: CAMARA Consent Management API, vwip - Operation createConsent
     And the request body property "$.consentTextId" is set to a value that does not match any valid consent text version for the requested scope(s) and purpose
     When the request "createConsent" is sent
     Then the response status code is 400
+    And the response header "x-correlator" has same value as the request header "x-correlator"
+    And the response header "Content-Type" is "application/json"
     And the response property "$.status" is 400
     And the response property "$.code" is "CONSENT_MGMT.INVALID_CONSENT_TEXT_ID"
     And the response property "$.message" contains a user friendly text
 
+  # Service Error scenarios
+
+  # Authentication/Authorization errors
+
   # Generic 401 errors
 
-  @consent_management_createConsent_401.1_no_authorization_header
-  Scenario: No Authorization header
-    Given the header "Authorization" is removed
-    And the request body is set to a valid request body
+  @consent_management_createConsent_401.01_no_authorization_header
+  Scenario: Error response for no header "Authorization"
+    Given the header "Authorization" is not sent
     When the request "createConsent" is sent
     Then the response status code is 401
+    And the response header "x-correlator" has same value as the request header "x-correlator"
+    And the response header "Content-Type" is "application/json"
     And the response property "$.status" is 401
     And the response property "$.code" is "UNAUTHENTICATED"
     And the response property "$.message" contains a user friendly text
 
-  @consent_management_createConsent_401.2_expired_access_token
-  Scenario: Expired access token
+  @consent_management_createConsent_401.02_expired_access_token
+  Scenario: Error response for expired access token
     Given the header "Authorization" is set to an expired access token
-    And the request body is set to a valid request body
     When the request "createConsent" is sent
     Then the response status code is 401
+    And the response header "x-correlator" has same value as the request header "x-correlator"
+    And the response header "Content-Type" is "application/json"
     And the response property "$.status" is 401
     And the response property "$.code" is "UNAUTHENTICATED"
     And the response property "$.message" contains a user friendly text
 
-  @consent_management_createConsent_401.3_invalid_access_token
-  Scenario: Invalid access token
+  @consent_management_createConsent_401.03_invalid_access_token
+  Scenario: Error response for invalid access token
     Given the header "Authorization" is set to an invalid access token
-    And the request body is set to a valid request body
     When the request "createConsent" is sent
     Then the response status code is 401
+    And the response header "x-correlator" has same value as the request header "x-correlator"
+    And the response header "Content-Type" is "application/json"
     And the response property "$.status" is 401
     And the response property "$.code" is "UNAUTHENTICATED"
     And the response property "$.message" contains a user friendly text
 
   # Generic 403 errors
 
-  @consent_management_createConsent_403.1_invalid_token_permissions
-  Scenario: Inconsistent access token permissions
-    # To test this scenario, it will be necessary to obtain a token without the required scope
-    Given the header "Authorization" is set to an access token without the required scope
-    And the request body is set to a valid request body
+  @consent_management_createConsent_403.01_missing_access_token_scope
+  Scenario: Missing access token scope
+    Given the header "Authorization" is set to an access token that does not include scope "consent-management:create"
     When the request "createConsent" is sent
     Then the response status code is 403
+    And the response header "x-correlator" has same value as the request header "x-correlator"
+    And the response header "Content-Type" is "application/json"
+    And the response property "$.status" is 403
+    And the response property "$.code" is "PERMISSION_DENIED"
+    And the response property "$.message" contains a user friendly text
+  
+  @consent_management_createConsent_403.02_api_client_token_mismatch
+  Scenario: Consent not created by the API client given in the access token
+    # To test this, a token has to be obtained for a different client
+    Given the header "Authorization" is set to a valid access token emitted to an API client which did not have rights to access/manage the Consent
+    When the request "createConsent" is sent
+    Then the response status code is 403
+    And the response header "x-correlator" has same value as the request header "x-correlator"
+    And the response header "Content-Type" is "application/json"
     And the response property "$.status" is 403
     And the response property "$.code" is "PERMISSION_DENIED"
     And the response property "$.message" contains a user friendly text
 
   # Specific 403 error scenarios
 
-  @consent_management_createConsent_403.2_not_allowed_scopes_purpose
+  @consent_management_createConsent_403.03_not_allowed_scopes_purpose
   # e.g. the API Consumer has not onboarded the appropriate API(s) with the API Provider for the declared purpose.
   Scenario: The requested scope(s) and purpose combination is not allowed
     Given a valid phone number identified by the token or provided in the request body
     And the request body properties "$.scopes" and "$.purpose" are set to a combination not allowed for the API Consumer
     When the request "createConsent" is sent
     Then the response status code is 403
+    And the response header "x-correlator" has same value as the request header "x-correlator"
+    And the response header "Content-Type" is "application/json"
     And the response property "$.status" is 403
     And the response property "$.code" is "CONSENT_MGMT.NOT_ALLOWED_SCOPES_PURPOSE"
     And the response property "$.message" contains a user friendly text
 
   # Generic 409 errors
 
-  @consent_management_createConsent_409.1_already_exists
-  Scenario: Trying to create an existing Consent resource
+  @consent_management_createConsent_409.01_duplicated_resource
+  Scenario: Conflict due to existing Consent
     Given a valid phone number identified by the token or provided in the request body
     And the request body property "$.scopes" is set to a valid scope list allowed for the API Consumer
     And the request body property "$.purpose" is set to a valid purpose for the requested scope(s)
@@ -263,6 +322,8 @@ Feature: CAMARA Consent Management API, vwip - Operation createConsent
     And a Consent for the given User, scope(s), and purpose already exists
     When the request "createConsent" is sent
     Then the response status code is 409
+    And the response header "x-correlator" has same value as the request header "x-correlator"
+    And the response header "Content-Type" is "application/json"
     And the response property "$.status" is 409
     And the response property "$.code" is "ALREADY_EXISTS"
     And the response property "$.message" contains a user friendly text

--- a/code/Test_definitions/consent-management-createConsent.feature
+++ b/code/Test_definitions/consent-management-createConsent.feature
@@ -282,7 +282,7 @@ Feature: CAMARA Consent Management API, vwip - Operation createConsent
     And the response property "$.status" is 403
     And the response property "$.code" is "PERMISSION_DENIED"
     And the response property "$.message" contains a user friendly text
-  
+
   @consent_management_createConsent_403.02_api_client_token_mismatch
   Scenario: Consent not created by the API client given in the access token
     # To test this, a token has to be obtained for a different client

--- a/code/Test_definitions/consent-management-retrieveConsentInfo.feature
+++ b/code/Test_definitions/consent-management-retrieveConsentInfo.feature
@@ -25,6 +25,8 @@ Feature: CAMARA Consent Management API, vwip - Operation retrieveConsentInfo
     And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"
     And the request body is set by default to a request body compliant with the schema at "#/components/schemas/RetrieveConsentInfoRequestBody"
 
+  ############################ Happy Path Scenarios #############################################
+
   # Success scenarios
 
   @consent_management_retrieveConsentInfo_01_generic_success
@@ -187,6 +189,8 @@ Feature: CAMARA Consent Management API, vwip - Operation retrieveConsentInfo
     And the response property "$[*].creationDate" is present and its value is in the past
     And the response property "$[*].expirationDate" is present and its value is in the past
 
+  ############################ Error Scenarios #############################################
+
   # Error scenarios for management of input parameter phoneNumber (C02)
 
   @consent_management_retrieveConsentInfo_C02.01_phone_number_not_schema_compliant
@@ -239,114 +243,166 @@ Feature: CAMARA Consent Management API, vwip - Operation retrieveConsentInfo
     And the response property "$.code" is "SERVICE_NOT_APPLICABLE"
     And the response property "$.message" contains a user friendly text
 
-  # Generic 400 errors
+  # Syntax Error scenarios
 
-  @consent_management_retrieveConsentInfo_400.1_no_request_body
-  Scenario: Missing request body
-    Given the request body is not included
+  @consent_management_retrieveConsentInfo_400.01_schema_not_compliant
+  Scenario: Invalid Argument. Generic Syntax Exception
+    Given the request body is included but is not compliant with the schema at "#/components/schemas/RetrieveConsentInfoRequestBody"
     When the request "retrieveConsentInfo" is sent
     Then the response status code is 400
+    And the response header "x-correlator" has same value as the request header "x-correlator"
+    And the response header "Content-Type" is "application/json"
     And the response property "$.status" is 400
     And the response property "$.code" is "INVALID_ARGUMENT"
     And the response property "$.message" contains a user friendly text
 
-  @consent_management_retrieveConsentInfo_400.2_missing_required_property
-  Scenario Outline: Missing required property in request body
-    Given the request body property "<input_property>" is not included
+  @consent_management_retrieveConsentInfo_400.02_no_request_body
+  Scenario: Missing request body
+    Given the request body is not included
     When the request "retrieveConsentInfo" is sent
     Then the response status code is 400
+    And the response header "x-correlator" has same value as the request header "x-correlator"
+    And the response header "Content-Type" is "application/json"
+    And the response property "$.status" is 400
+    And the response property "$.code" is "INVALID_ARGUMENT"
+    And the response property "$.message" contains a user friendly text
+
+  @consent_management_retrieveConsentInfo_400.03_empty_request_body
+  # 3-legged scenario only. It happens when request body has at least one required property
+  # NOTE: Recommended value for "$.message" (NOT NORMATIVE) is "Missing mandatory parameter(s)"
+  Scenario: Empty object as request body
+    Given the request body is set to {}
+    When the request "retrieveConsentInfo" is sent
+    Then the response status code is 400
+    And the response header "x-correlator" has same value as the request header "x-correlator"
+    And the response header "Content-Type" is "application/json"
+    And the response property "$.status" is 400
+    And the response property "$.code" is "INVALID_ARGUMENT"
+    And the response property "$.message" contains a user friendly text
+
+  @consent_management_retrieveConsentInfo_400.04_missing_required_property
+  Scenario Outline: Error response for missing required property in request body
+    Given the request body property "<required_property>" is not included
+    When the request "retrieveConsentInfo" is sent
+    Then the response status code is 400
+    And the response header "x-correlator" has same value as the request header "x-correlator"
+    And the response header "Content-Type" is "application/json"
     And the response property "$.status" is 400
     And the response property "$.code" is "INVALID_ARGUMENT"
     And the response property "$.message" contains a user friendly text
 
     Examples:
-      | input_property      |
-      | $.scopes            |
-      | $.purpose           |
-      | $.requestConsentText |
+      | required_property       |
+      | $.scopes                |
+      | $.purpose               |
+      | $.requestConsentText    |
 
-  @consent_management_retrieveConsentInfo_400.3_scopes_empty_array
+  @consent_management_retrieveConsentInfo_400.05_invalid_x-correlator
+  Scenario: Invalid x-correlator header
+    Given the header "x-correlator" does not comply with the schema at "#/components/schemas/XCorrelator"
+    When the request "retrieveConsentInfo" is sent
+    Then the response status code is 400
+    And the response property "$.status" is 400
+    And the response property "$.code" is "INVALID_ARGUMENT"
+    And the response property "$.message" contains a user friendly text
+
+  @consent_management_retrieveConsentInfo_400.06_scopes_empty_array
   Scenario: The scopes field is an empty array
     Given the request body property "$.scopes" is set to []
     When the request "retrieveConsentInfo" is sent
     Then the response status code is 400
+    And the response header "x-correlator" has same value as the request header "x-correlator"
+    And the response header "Content-Type" is "application/json"
     And the response property "$.status" is 400
     And the response property "$.code" is "INVALID_ARGUMENT"
     And the response property "$.message" contains a user friendly text
 
-  @consent_management_retrieveConsentInfo_400.4_purpose_invalid_format
+  @consent_management_retrieveConsentInfo_400.07_purpose_invalid_format
   Scenario: The purpose field does not comply with the required format
     Given the request body property "$.purpose" does not comply with the OAS schema at "#/components/schemas/Purpose"
     When the request "retrieveConsentInfo" is sent
     Then the response status code is 400
+    And the response header "x-correlator" has same value as the request header "x-correlator"
+    And the response header "Content-Type" is "application/json"
     And the response property "$.status" is 400
     And the response property "$.code" is "INVALID_ARGUMENT"
     And the response property "$.message" contains a user friendly text
 
-  @consent_management_retrieveConsentInfo_400.5_x_correlator_not_compliant
-  Scenario: Invalid x-correlator header
-    Given the header "x-correlator" is set to a value which is not compliant with the schema at "#/components/schemas/XCorrelator"
-    And the request body is set to a valid request body
-    When the request "retrieveConsentInfo" is sent
-    Then the response status code is 400
-    And the response property "$.status" is 400
-    And the response property "$.code" is "INVALID_ARGUMENT"
-    And the response property "$.message" contains a user friendly text
+  # Service Error scenarios
+
+  # Authentication/Authorization errors
 
   # Generic 401 errors
 
-  @consent_management_retrieveConsentInfo_401.1_no_authorization_header
-  Scenario: No Authorization header
-    Given the header "Authorization" is removed
-    And the request body is set to a valid request body
+  @consent_management_retrieveConsentInfo_401.01_no_authorization_header
+  Scenario: Error response for no header "Authorization"
+    Given the header "Authorization" is not sent
     When the request "retrieveConsentInfo" is sent
     Then the response status code is 401
+    And the response header "x-correlator" has same value as the request header "x-correlator"
+    And the response header "Content-Type" is "application/json"
     And the response property "$.status" is 401
     And the response property "$.code" is "UNAUTHENTICATED"
     And the response property "$.message" contains a user friendly text
 
-  @consent_management_retrieveConsentInfo_401.2_expired_access_token
-  Scenario: Expired access token
+  @consent_management_retrieveConsentInfo_401.02_expired_access_token
+  Scenario: Error response for expired access token
     Given the header "Authorization" is set to an expired access token
-    And the request body is set to a valid request body
     When the request "retrieveConsentInfo" is sent
     Then the response status code is 401
+    And the response header "x-correlator" has same value as the request header "x-correlator"
+    And the response header "Content-Type" is "application/json"
     And the response property "$.status" is 401
     And the response property "$.code" is "UNAUTHENTICATED"
     And the response property "$.message" contains a user friendly text
 
-  @consent_management_retrieveConsentInfo_401.3_invalid_access_token
-  Scenario: Invalid access token
+  @consent_management_retrieveConsentInfo_401.03_invalid_access_token
+  Scenario: Error response for invalid access token
     Given the header "Authorization" is set to an invalid access token
-    And the request body is set to a valid request body
     When the request "retrieveConsentInfo" is sent
     Then the response status code is 401
+    And the response header "x-correlator" has same value as the request header "x-correlator"
+    And the response header "Content-Type" is "application/json"
     And the response property "$.status" is 401
     And the response property "$.code" is "UNAUTHENTICATED"
     And the response property "$.message" contains a user friendly text
 
   # Generic 403 errors
 
-  @consent_management_retrieveConsentInfo_403.1_invalid_token_permissions
-  Scenario: Inconsistent access token permissions
-    # To test this scenario, it will be necessary to obtain a token without the required scope
-    Given the header "Authorization" is set to an access token without the required scope
-    And the request body is set to a valid request body
+  @consent_management_retrieveConsentInfo_403.01_missing_access_token_scope
+  Scenario: Missing access token scope
+    Given the header "Authorization" is set to an access token that does not include scope "consent-management:retrieve-info"
     When the request "retrieveConsentInfo" is sent
     Then the response status code is 403
+    And the response header "x-correlator" has same value as the request header "x-correlator"
+    And the response header "Content-Type" is "application/json"
+    And the response property "$.status" is 403
+    And the response property "$.code" is "PERMISSION_DENIED"
+    And the response property "$.message" contains a user friendly text
+
+  @consent_management_retrieveConsentInfo_403.02_api_client_token_mismatch
+  Scenario: Consent info not accessible by the API client given in the access token
+    # To test this, a token has to be obtained for a different client
+    Given the header "Authorization" is set to a valid access token emitted to an API client which did not have rights to access/manage the Consent
+    When the request "retrieveConsentInfo" is sent
+    Then the response status code is 403
+    And the response header "x-correlator" has same value as the request header "x-correlator"
+    And the response header "Content-Type" is "application/json"
     And the response property "$.status" is 403
     And the response property "$.code" is "PERMISSION_DENIED"
     And the response property "$.message" contains a user friendly text
 
   # Specific 403 error scenarios
 
-  @consent_management_retrieveConsentInfo_403.2_not_allowed_scopes_purpose
+  @consent_management_retrieveConsentInfo_403.03_not_allowed_scopes_purpose
   # e.g. the API Consumer has not onboarded the appropriate API(s) with the API Provider for the declared purpose.
   Scenario: The requested scope(s) and purpose combination is not allowed
     Given a valid phone number identified by the token or provided in the request body
     And the request body properties "$.scopes" and "$.purpose" are set to a combination not allowed for the API Consumer
     When the request "retrieveConsentInfo" is sent
     Then the response status code is 403
+    And the response header "x-correlator" has same value as the request header "x-correlator"
+    And the response header "Content-Type" is "application/json"
     And the response property "$.status" is 403
     And the response property "$.code" is "CONSENT_MGMT.NOT_ALLOWED_SCOPES_PURPOSE"
     And the response property "$.message" contains a user friendly text

--- a/code/Test_definitions/consent-management-updateConsent.feature
+++ b/code/Test_definitions/consent-management-updateConsent.feature
@@ -22,6 +22,9 @@ Feature: CAMARA Consent Management API, vwip - Operation updateConsent
     And the header "Authorization" is set to a valid access token
     And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"
     And the request body is set by default to a request body compliant with the schema at "#/components/schemas/UpdateConsentRequestBody"
+    And the path parameter "consentId" is set by default to an existing value
+
+  ############################ Happy Path Scenarios #############################################
 
   # Success scenarios
 
@@ -53,97 +56,141 @@ Feature: CAMARA Consent Management API, vwip - Operation updateConsent
     And the response property "$.creationDate" is present
     And the response property "$.expirationDate" is present and its value is in the future
 
-  # Generic 400 errors
+  ############################ Error Scenarios #############################################
 
-  @consent_management_updateConsent_400.1_no_request_body
+  # Syntax Error scenarios
+
+  @consent_management_updateConsent_400.01_schema_not_compliant
+  Scenario: Invalid Argument. Generic Syntax Exception
+    Given the request body is included but is not compliant with the schema at "#/components/schemas/UpdateConsentRequestBody"
+    When the request "updateConsent" is sent
+    Then the response status code is 400
+    And the response header "x-correlator" has same value as the request header "x-correlator"
+    And the response header "Content-Type" is "application/json"
+    And the response property "$.status" is 400
+    And the response property "$.code" is "INVALID_ARGUMENT"
+    And the response property "$.message" contains a user friendly text
+
+  @consent_management_updateConsent_400.02_no_request_body
   Scenario: Missing request body
     Given the request body is not included
     When the request "updateConsent" is sent
     Then the response status code is 400
+    And the response header "x-correlator" has same value as the request header "x-correlator"
+    And the response header "Content-Type" is "application/json"
     And the response property "$.status" is 400
     And the response property "$.code" is "INVALID_ARGUMENT"
     And the response property "$.message" contains a user friendly text
 
-  @consent_management_updateConsent_400.2_missing_consentStatus
-  Scenario: Missing required field consentStatus
-    Given the request body property "$.consentStatus" is not included
+  @consent_management_updateConsent_400.03_missing_required_property
+  Scenario: Error response for missing required property in request body
+    Given the request body property "<required_property>" is not included
+    When the request "updateConsent" is sent
+    Then the response status code is 400
+    And the response header "x-correlator" has same value as the request header "x-correlator"
+    And the response header "Content-Type" is "application/json"
+    And the response property "$.status" is 400
+    And the response property "$.code" is "INVALID_ARGUMENT"
+    And the response property "$.message" contains a user friendly text
+
+    Examples:
+      | required_property |
+      | $.consentStatus   |
+
+  @consent_management_updateConsent_400.04_invalid_x-correlator
+  Scenario: Invalid x-correlator header
+    Given the header "x-correlator" does not comply with the schema at "#/components/schemas/XCorrelator"
     When the request "updateConsent" is sent
     Then the response status code is 400
     And the response property "$.status" is 400
     And the response property "$.code" is "INVALID_ARGUMENT"
     And the response property "$.message" contains a user friendly text
 
-  @consent_management_updateConsent_400.3_consentStatus_invalid_value
+  @consent_management_updateConsent_400.05_consentStatus_invalid_value
   Scenario: The consentStatus field has an invalid value
     Given the request body property "$.consentStatus" is set to a value not in the allowed enum ["GRANTED", "DENIED"]
     When the request "updateConsent" is sent
     Then the response status code is 400
+    And the response header "x-correlator" has same value as the request header "x-correlator"
+    And the response header "Content-Type" is "application/json"
     And the response property "$.status" is 400
     And the response property "$.code" is "INVALID_ARGUMENT"
     And the response property "$.message" contains a user friendly text
 
-  @consent_management_updateConsent_400.4_x_correlator_not_compliant
-  Scenario: Invalid x-correlator header
-    Given the header "x-correlator" is set to a value which is not compliant with the schema at "#/components/schemas/XCorrelator"
-    And the request body is set to a valid request body
-    When the request "updateConsent" is sent
-    Then the response status code is 400
-    And the response property "$.status" is 400
-    And the response property "$.code" is "INVALID_ARGUMENT"
-    And the response property "$.message" contains a user friendly text
+  # Service Error scenarios
+
+  # Authentication/Authorization errors
 
   # Generic 401 errors
 
-  @consent_management_updateConsent_401.1_no_authorization_header
-  Scenario: No Authorization header
-    Given the header "Authorization" is removed
-    And the request body is set to a valid request body
+  @consent_management_updateConsent_401.01_no_authorization_header
+  Scenario: Error response for no header "Authorization"
+    Given the header "Authorization" is not sent
     When the request "updateConsent" is sent
     Then the response status code is 401
+    And the response header "x-correlator" has same value as the request header "x-correlator"
+    And the response header "Content-Type" is "application/json"
     And the response property "$.status" is 401
     And the response property "$.code" is "UNAUTHENTICATED"
     And the response property "$.message" contains a user friendly text
 
-  @consent_management_updateConsent_401.2_expired_access_token
-  Scenario: Expired access token
+  @consent_management_updateConsent_401.02_expired_access_token
+  Scenario: Error response for expired access token
     Given the header "Authorization" is set to an expired access token
-    And the request body is set to a valid request body
     When the request "updateConsent" is sent
     Then the response status code is 401
+    And the response header "x-correlator" has same value as the request header "x-correlator"
+    And the response header "Content-Type" is "application/json"
     And the response property "$.status" is 401
     And the response property "$.code" is "UNAUTHENTICATED"
     And the response property "$.message" contains a user friendly text
 
-  @consent_management_updateConsent_401.3_invalid_access_token
-  Scenario: Invalid access token
+  @consent_management_updateConsent_401.03_invalid_access_token
+  Scenario: Error response for invalid access token
     Given the header "Authorization" is set to an invalid access token
-    And the request body is set to a valid request body
     When the request "updateConsent" is sent
     Then the response status code is 401
+    And the response header "x-correlator" has same value as the request header "x-correlator"
+    And the response header "Content-Type" is "application/json"
     And the response property "$.status" is 401
     And the response property "$.code" is "UNAUTHENTICATED"
     And the response property "$.message" contains a user friendly text
 
   # Generic 403 errors
 
-  @consent_management_updateConsent_403.1_invalid_token_permissions
-  Scenario: Inconsistent access token permissions
-    # To test this scenario, it will be necessary to obtain a token without the required scope
-    Given the header "Authorization" is set to an access token without the required scope
-    And the request body is set to a valid request body
+  @consent_management_updateConsent_403.01_missing_access_token_scope
+  Scenario: Missing access token scope
+    Given the header "Authorization" is set to an access token that does not include scope "consent-management:update"
     When the request "updateConsent" is sent
     Then the response status code is 403
+    And the response header "x-correlator" has same value as the request header "x-correlator"
+    And the response header "Content-Type" is "application/json"
+    And the response property "$.status" is 403
+    And the response property "$.code" is "PERMISSION_DENIED"
+    And the response property "$.message" contains a user friendly text
+
+  @consent_management_updateConsent_403.02_api_client_token_mismatch
+  Scenario: Consent not managed by the API client given in the access token
+    # To test this, a token has to be obtained for a different client
+    Given the header "Authorization" is set to a valid access token emitted to an API client which did not have rights to access/manage the Consent
+    When the request "updateConsent" is sent
+    Then the response status code is 403
+    And the response header "x-correlator" has same value as the request header "x-correlator"
+    And the response header "Content-Type" is "application/json"
     And the response property "$.status" is 403
     And the response property "$.code" is "PERMISSION_DENIED"
     And the response property "$.message" contains a user friendly text
 
   # Generic 404 errors
 
-  @consent_management_updateConsent_404.1_consent_not_found
-  Scenario: Consent ID not found
-    Given the path parameter "consentId" is set to a value that does not exist
+  @consent_management_updateConsent_404.01_not_found
+  Scenario: non-existing consentId
+    Given the path parameter "consentId" is set to a random UUID
     When the request "updateConsent" is sent
     Then the response status code is 404
+    And the response header "x-correlator" has same value as the request header "x-correlator"
+    And the response header "Content-Type" is "application/json"
     And the response property "$.status" is 404
     And the response property "$.code" is "NOT_FOUND"
     And the response property "$.message" contains a user friendly text
+

--- a/code/Test_definitions/consent-management-updateConsent.feature
+++ b/code/Test_definitions/consent-management-updateConsent.feature
@@ -193,4 +193,3 @@ Feature: CAMARA Consent Management API, vwip - Operation updateConsent
     And the response property "$.status" is 404
     And the response property "$.code" is "NOT_FOUND"
     And the response property "$.message" contains a user friendly text
-


### PR DESCRIPTION
#### What type of PR is this?

* enhancement/feature
* repository management

#### What this PR does / why we need it:

This PR updates the Consent Management API specification and test definitions to align with [CAMARA Commonalities r4.3](https://github.com/camaraproject/Commonalities/releases/tag/r4.3) (Commonalities 0.8.0).

**API Specification (`consent-management.yaml`):**
- Updated `x-camara-commonalities` version from `0.6` to `0.8.0`
- Replaced inline definitions for `x-correlator` header/parameter, `PhoneNumber`, and `ErrorInfo` with `$ref` to `CAMARA_common.yaml`, removing duplicated schema definitions
- Replaced inline `Generic401` response with `$ref` to `CAMARA_common.yaml`
- Removed unused `XCorrelator` schema component (rule S-211)
- Added mandatory CAMARA `info.description` section markers (`authorization-and-authentication`, `identifying-phone-number-from-access-token`, `additional-error-responses`, `request-body-strictness`)
- Added `maxLength` constraints to all string properties across request/response schemas to comply with rule S-312: `consentId`, `Scopes` items, `Purpose`, `ConsentTextId`, `LanguageTags`, `CreationDate`, `ExpirationDate`, `ConsentText.title`, `ConsentText.description`, `ConsentText.lastUpdate`
- Added `maxItems` constraints to array schemas (`Scopes`: 50, `RetrieveConsentInfoResponseBody`: 100) to comply with rule S-309
- Added `description` to array items (`Scopes`) and object schemas (`ConsentInfoItem`) to comply with rules S-031 and S-011
- Added BCP 47 `pattern` validation to `LanguageTags` schema

**Test Definitions (all three `.feature` files):**
- Aligned structure and scenario organisation with the [CAMARA sample-service-template.feature](https://github.com/camaraproject/Commonalities/blob/main/artifacts/testing/sample-service-template.feature):
  - Added `Happy Path Scenarios` and `Error Scenarios` section banners
  - Added `Syntax Error scenarios` and `Service Error scenarios` subsection headers
  - Renumbered all error scenario tags to double-digit format (`400.01`–`400.0x`, `401.01`–`401.03`, `403.01`–`403.0x`, etc.)
  - Added `x-correlator` and `Content-Type` response header assertion steps to all error scenarios (except `400.05_invalid_x-correlator`)
  - Added three new generic error scenarios per operation: `400.01_schema_not_compliant`, `400.03_empty_request_body`, and `429.01_too_many_requests`
  - Added `403.02_api_client_token_mismatch` scenario to all three operations
  - Updated `401.0x` scenarios to remove redundant `request body` setup step and align title/step wording with the template
  - Updated `403.01` to explicitly reference the required OAuth2 scope per operation (`consent-management:create/update/retrieve-info`)
  - Updated `400.05_invalid_x-correlator` step wording to match the template (`"does not comply with"`)
- `updateConsent.feature` additionally: added default path parameter `consentId` in Background; updated `404.01` step to use a random UUID; added `x-correlator` + `Content-Type` response header checks to 404 scenario
- `createConsent.feature` additionally: fixed `400.01_schema_not_compliant` to reference `CreateConsentRequestBody` (not the response schema)

#### Which issue(s) this PR fixes:

Fixes #17 

#### Special notes for reviewers:

- @rartych @hdamker @PedroDiez You might be interested in this PR, as it is one of the first to adapt an API and its test definitions to Spring26 Commonalities.

#### Changelog input

```
 release-note
```

#### Additional documentation 

- https://lf-camaraproject.atlassian.net/wiki/spaces/CAM/pages/789086209/Analysis+of+Commonalities+0.8.0
- https://github.com/camaraproject/Commonalities/releases/tag/r4.3
