### PR TITLE
Fix externalDocs link

### DIFF
--- a/code/API_definitions/consent-management.yaml
+++ b/code/API_definitions/consent-management.yaml
@@ -129,7 +129,7 @@ info:
   x-camara-commonalities: 0.8.0
 externalDocs:
   description: Product documentation at CAMARA
-  url: https://github.com/camaraproject/ConsentInfo
+  url: https://github.com/camaraproject/ConsentManagement
 servers:
   - url: "{apiRoot}/consent-management/vwip"
     variables:


### PR DESCRIPTION
#### What type of PR is this?

* correction

#### What this PR does / why we need it:

This pull request makes a small update to the external documentation link in the OpenAPI definition. The link now correctly points to the `ConsentManagement` repository instead of the old `ConsentInfo` repository.

#### Which issue(s) this PR fixes:

N/A

#### Special notes for reviewers:

This issue was raised during the r1.1 release review at https://github.com/camaraproject/ConsentManagement/pull/30#pullrequestreview-4403611897, and it was agreed that it would be fixed before the public release, without delaying the completion of r1.1.

#### Changelog input

```
externalDocs url fix
```

#### Additional documentation 

N/A
