### PR TITLE
Public release r1.2 plan

### DIFF
--- a/release-plan.yaml
+++ b/release-plan.yaml
@@ -16,11 +16,11 @@ repository:
   # Release tag -- first release for a repository is r1.1
   # - New release cycle (increment first number, reset second to 1)
   # - Progression in same cycle (increment second number)
-  target_release_tag: r1.1
+  target_release_tag: r1.2
 
   # Release type being prepared (must be set before release can be triggered)
   # Options: none | pre-release-alpha | pre-release-rc | public-release | maintenance-release
-  target_release_type: pre-release-rc
+  target_release_type: public-release
 
 # Dependencies on Commonalities and ICM releases
 # Update per ReleaseManagement requirements for each release cycle
@@ -35,7 +35,7 @@ dependencies:
 apis:
   - api_name: consent-management
     target_api_version: 0.1.0
-    target_api_status: rc
+    target_api_status: public
     main_contacts:
       - jpengar
       - AxelNennker


### PR DESCRIPTION
#### What type of PR is this?

* repository management

#### What this PR does / why we need it:

This pull request updates the release plan to move from a release candidate to a public release.

Release configuration updates:

* Updated `target_release_tag` in `release-plan.yaml` from `r1.1` to `r1.2`.
* Changed `target_release_type` in `release-plan.yaml` from `pre-release-rc` to `public-release`.

Dependency status update:

* Set `target_api_status` for the `consent-management` API from `rc` to `public` in `release-plan.yaml`.

#### Which issue(s) this PR fixes:

N/A

#### Special notes for reviewers:

As agreed in https://lf-camaraproject.atlassian.net/wiki/spaces/CAM/pages/880934924/2026-06-17+ICM+Minutes, the WG has decided to proceed with public release planning for the Consent Management API.

#### Changelog input

```
Release plan update for public release
```

#### Additional documentation 

N/A
