### PR TITLE
Fix Herbert's review comments in #35

### DIFF
--- a/code/API_definitions/consent-management.yaml
+++ b/code/API_definitions/consent-management.yaml
@@ -762,7 +762,7 @@ components:
                   code:
                     enum:
                       - INVALID_ARGUMENT
-                      - CONSENT_MGMT.INVALID_CONSENT_TEXT_ID
+                      - CONSENT_MANAGEMENT.INVALID_CONSENT_TEXT_ID
           examples:
             GENERIC_400_INVALID_ARGUMENT:
               description: Invalid Argument. Generic Syntax Exception
@@ -774,7 +774,7 @@ components:
               description: The provided consentTextId does not match any valid consent text version available for the requested scope(s) and Purpose.
               value:
                 status: 400
-                code: CONSENT_MGMT.INVALID_CONSENT_TEXT_ID
+                code: CONSENT_MANAGEMENT.INVALID_CONSENT_TEXT_ID
                 message: The consentTextId provided is either invalid or does not exist.
     Generic401:
       $ref: "../common/CAMARA_common.yaml#/components/responses/Generic401"
@@ -821,7 +821,7 @@ components:
                   code:
                     enum:
                       - PERMISSION_DENIED
-                      - CONSENT_MGMT.NOT_ALLOWED_SCOPES_PURPOSE
+                      - CONSENT_MANAGEMENT.NOT_ALLOWED_SCOPES_PURPOSE
           examples:
             GENERIC_403_PERMISSION_DENIED:
               description: Permission denied. OAuth2 token access does not have the required scope or when the user fails operational security
@@ -833,7 +833,7 @@ components:
               description: The requested scope(s) and Purpose combination is not allowed for the API Consumer, e.g. the API Consumer has not onboarded the appropriate API(s) with the API Provider for the declared Purpose.
               value:
                 status: 403
-                code: CONSENT_MGMT.NOT_ALLOWED_SCOPES_PURPOSE
+                code: CONSENT_MANAGEMENT.NOT_ALLOWED_SCOPES_PURPOSE
                 message: The requested scope(s) and Purpose combination is not allowed for this API Consumer.
     Generic404:
       $ref: "../common/CAMARA_common.yaml#/components/responses/Generic404"

--- a/code/Test_definitions/consent-management-createConsent.feature
+++ b/code/Test_definitions/consent-management-createConsent.feature
@@ -154,7 +154,7 @@ Feature: CAMARA Consent Management API, vwip - Operation createConsent
     And the response property "$.code" is "INVALID_ARGUMENT"
     And the response property "$.message" contains a user friendly text
 
-  @consent_management_createConsent_400.04_missing_required_property-
+  @consent_management_createConsent_400.04_missing_required_property
   Scenario Outline: Error response for missing required property in request body
     Given the request body property "<required_property>" is not included
     When the request "createConsent" is sent

--- a/code/Test_definitions/consent-management-createConsent.feature
+++ b/code/Test_definitions/consent-management-createConsent.feature
@@ -228,7 +228,7 @@ Feature: CAMARA Consent Management API, vwip - Operation createConsent
     And the response header "x-correlator" has same value as the request header "x-correlator"
     And the response header "Content-Type" is "application/json"
     And the response property "$.status" is 400
-    And the response property "$.code" is "CONSENT_MGMT.INVALID_CONSENT_TEXT_ID"
+    And the response property "$.code" is "CONSENT_MANAGEMENT.INVALID_CONSENT_TEXT_ID"
     And the response property "$.message" contains a user friendly text
 
   # Service Error scenarios
@@ -307,7 +307,7 @@ Feature: CAMARA Consent Management API, vwip - Operation createConsent
     And the response header "x-correlator" has same value as the request header "x-correlator"
     And the response header "Content-Type" is "application/json"
     And the response property "$.status" is 403
-    And the response property "$.code" is "CONSENT_MGMT.NOT_ALLOWED_SCOPES_PURPOSE"
+    And the response property "$.code" is "CONSENT_MANAGEMENT.NOT_ALLOWED_SCOPES_PURPOSE"
     And the response property "$.message" contains a user friendly text
 
   # Generic 409 errors

--- a/code/Test_definitions/consent-management-retrieveConsentInfo.feature
+++ b/code/Test_definitions/consent-management-retrieveConsentInfo.feature
@@ -404,5 +404,5 @@ Feature: CAMARA Consent Management API, vwip - Operation retrieveConsentInfo
     And the response header "x-correlator" has same value as the request header "x-correlator"
     And the response header "Content-Type" is "application/json"
     And the response property "$.status" is 403
-    And the response property "$.code" is "CONSENT_MGMT.NOT_ALLOWED_SCOPES_PURPOSE"
+    And the response property "$.code" is "CONSENT_MANAGEMENT.NOT_ALLOWED_SCOPES_PURPOSE"
     And the response property "$.message" contains a user friendly text

--- a/code/Test_definitions/consent-management-updateConsent.feature
+++ b/code/Test_definitions/consent-management-updateConsent.feature
@@ -83,7 +83,7 @@ Feature: CAMARA Consent Management API, vwip - Operation updateConsent
     And the response property "$.message" contains a user friendly text
 
   @consent_management_updateConsent_400.03_missing_required_property
-  Scenario: Error response for missing required property in request body
+  Scenario Outline: Error response for missing required property in request body
     Given the request body property "<required_property>" is not included
     When the request "updateConsent" is sent
     Then the response status code is 400


### PR DESCRIPTION
#### What type of PR is this?

* correction

#### What this PR does / why we need it:

This pull request fixes the review comments raised by @hdamker in #35.

Corrections applied:

* Updated all error code enums and example values in `consent-management.yaml` to use the `CONSENT_MANAGEMENT` prefix instead of `CONSENT_MGMT`.
* Fixed a typo in the tag for the missing required property test scenario in `consent-management-createConsent.feature`.
* Changed the "missing required property" scenario for `updateConsent` to a scenario outline, allowing parameterization of required properties in `consent-management-updateConsent.feature`.

#### Which issue(s) this PR fixes:

N/A

#### Special notes for reviewers:

Further details at https://github.com/camaraproject/ConsentManagement/pull/35#pullrequestreview-4695966310

#### Changelog input

N/A

#### Additional documentation 

N/A
